### PR TITLE
Allow ELLog and THGLog to coexist

### DIFF
--- a/ELLog/Logger-Objc.h
+++ b/ELLog/Logger-Objc.h
@@ -18,13 +18,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 };
 
 
-@interface LoggerObjc: NSObject
+@interface ELLoggerObjc: NSObject
 + (void)log:(id)instance logLevel:(NSUInteger)level function:(NSString *)function filename:(NSString *)filename line:(NSUInteger)line format:(NSString *)format, ...;
 @end
 
 
 #define ELLogCustom(instance, lvl, frmt, ...) \
-    [LoggerObjc log:instance \
+    [ELLoggerObjc log:instance \
            logLevel:lvl \
            function:[NSString stringWithUTF8String:__PRETTY_FUNCTION__] \
            filename:[NSString stringWithUTF8String:__FILE__] \

--- a/ELLog/Logger-Objc.m
+++ b/ELLog/Logger-Objc.m
@@ -9,7 +9,7 @@
 #import "Logger-Objc.h"
 #import <ELLog/ELLog-Swift.h>
 
-@implementation LoggerObjc
+@implementation ELLoggerObjc
 
 + (void)log:(ELLogger *)instance logLevel:(NSUInteger)level function:(NSString *)function filename:(NSString *)filename line:(NSUInteger)line format:(NSString *)format, ... {
     va_list argp;


### PR DESCRIPTION
This commit namespaces LoggerObjC to ELLoggerObjC. This is because we cannot reference modules in Objective-C, and allows us to have ELLog and THGLog in the same app. This is not a desired feature, of course, but our frameworks should be as namespace collision free as possible.

Please delete the branch after merging
