### PR TITLE
Refactored LogDestinationBase, related protocols

### DIFF
--- a/ELLog/Destinations/LogConsoleDestination.swift
+++ b/ELLog/Destinations/LogConsoleDestination.swift
@@ -19,46 +19,23 @@ The default behavior is:
     showTimestamp = false
 */
 @objc(ELLogConsoleDestination)
-public class LogConsoleDestination: LogDestinationBase, LogDestinationProtocol {
+public class LogConsoleDestination: LogDestinationBase {
 
-    // LogDestinationProtocol compliance
-    public var showCaller: Bool = false
-    public var showLogLevel: Bool = true
-    public var showTimestamp: Bool = false
-
-    public func log(detail: LogDetail) {
-        NSLog(formattedLogString(detail))
+    public override init(level: LogLevel) {
+        super.init(level: level)
+        showCaller = false
+        showLogLevel = true
+        showTimestamp = false
     }
     
-    internal func formattedLogString(detail: LogDetail) -> String {
-        var logString: String = ""
-        
-        if showLogLevel {
-            if let level = detail.level {
-                logString += "[\(LogLevel(rawValue: level).description)] "
-            }
-        }
-        
-        if showTimestamp {
-            if let date = detail.date {
-                logString += "[\(dateFormatter.stringFromDate(date))] "
-            }
-        }
-        
-        if showCaller {
-            if let filename = detail.filename, line = detail.line, function = detail.function {
-                logString += "(\(function), \((filename as NSString).lastPathComponent):\(line)) "
-            }
-        }
-        
-        logString += ": "
-        
-        if let message = detail.message {
-            logString += message
-        }
-        
-        return logString
+    public convenience init() {
+        self.init(level: .Debug)
     }
+    
+    public override func log(detail: LogDetail) {
+        NSLog(formatted(detail))
+    }
+    
 }
 
 

--- a/ELLog/Destinations/LogTextfileDestination.swift
+++ b/ELLog/Destinations/LogTextfileDestination.swift
@@ -20,13 +20,8 @@ The default behavior is:
     showTimestamp = true
 */
 @objc(ELLogTextfileDestination)
-public class LogTextfileDestination: LogDestinationBase, LogDestinationProtocol {
+public class LogTextfileDestination: LogDestinationBase {
 
-    // LogDestinationProtocol compliance
-    public var showCaller: Bool = false
-    public var showLogLevel: Bool = true
-    public var showTimestamp: Bool = true
-    
     private let filename: String
     private let outputStream: NSOutputStream?
 
@@ -44,47 +39,23 @@ public class LogTextfileDestination: LogDestinationBase, LogDestinationProtocol 
         }
 
         super.init(level: .Debug)
+        
+        showCaller = false
+        showLogLevel = true
+        showTimestamp = true
     }
 
     deinit {
         outputStream?.close()
     }
 
-    public func log(detail: LogDetail) {
+    public override func log(detail: LogDetail) {
 
         if outputStream == nil {
             return
         }
         
-        var output: String = ""
-
-        if showLogLevel {
-            if let level = detail.level {
-                output += "[\(LogLevel(rawValue: level).description)] "
-            }
-        }
-
-        if showTimestamp {
-            if let date = detail.date {
-                output += "[\(dateFormatter.stringFromDate(date))] "
-            }
-        }
-
-        if showCaller {
-            if let filename = detail.filename, line = detail.line, function = detail.function {
-                output += "(\(function), \((filename as NSString).lastPathComponent):\(line)) "
-            }
-        }
-
-        output += ": "
-
-        if let message = detail.message {
-            output += message
-        }
-
-        output += "\n"
-
-        outputStream?.write(output)
+        outputStream?.write(formatted(detail))
     }
 }
 

--- a/ELLog/LogDestinationBase.swift
+++ b/ELLog/LogDestinationBase.swift
@@ -18,36 +18,60 @@ public protocol LogDestinationProtocol: class {
     - parameter detail: Detailed information about the log statement.
     */
     func log(detail: LogDetail)
+    
     /**
     A unique identifier representing this destination.
     */
     var identifier: String { get }
+    
     /**
     The levels that this destination actually records.  See LogLevel.
     */
     var level: UInt { get set }
-    /// Specifies whether this destination should show the caller information.
-    var showCaller: Bool { get set }
-    /// Specifies whether this destination should show the log level.
-    var showLogLevel: Bool { get set }
-    /// Specifies whether this destination should show the timestampe.
-    var showTimestamp: Bool { get set }
 }
 
+@objc(ELLogDestinationFormattible)
+public protocol LogDestinationFormattible: class {
+    /// Specifies whether this destination should show the caller information.
+    var showCaller: Bool { get }
+    
+    /// Specifies whether this destination should show the log level.
+    var showLogLevel: Bool { get set }
+    
+    /// Specifies whether this destination should show the timestamp.
+    var showTimestamp: Bool { get set }
+    
+    /// The dateformatter that will be used to format the timestamp.
+    var dateFormatter: NSDateFormatter { get }
+    
+    /**
+     Converts a `LogDetail` into a formatted string based on the current properties.
+     This is what you should output into the destination verbatim.
+     
+     - parameter detail: The `LogDetail` that to be formatted for the destination.
+     - returns: The formatted string.
+     */
+    func formatted(detail: LogDetail) -> String
+}
 
 /// A struct describing a log message in detail.
 @objc(ELLogDetail)
 public class LogDetail: NSObject {
     /// The date at which the log call was made.  Note: This will never be an exact time, but approximate.
     public var date: NSDate? = nil
+    
     /// The message.
     public var message: String? = nil
+    
     /// The level at which this was logged.
     public var level: UInt? = .None
+    
     /// The function in which log was called.
     public var function: String? = nil
+    
     /// The filename in which log was called.
     public var filename: String? = nil
+    
     /// The line number which called log.
     public var line: UInt? = nil
 }
@@ -59,18 +83,64 @@ Provides a default identifier (a GUID), a default level of .Debug, and a date fo
 use with output timestamps.
 */
 @objc(ELLogDestinationBase)
-public class LogDestinationBase: NSObject {
+public class LogDestinationBase: NSObject, LogDestinationProtocol, LogDestinationFormattible {
+    
+    private static let DateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+    
     public init(level: LogLevel) {
         self.level = level.rawValue
+        showCaller = false
+        showLogLevel = false
+        showTimestamp = false
+        dateFormatter = NSThread.dateFormatter_ELLog(LogDestinationBase.DateFormat)
     }
 
-    public override init() {
-        level = LogLevel.Debug.rawValue
+    public override convenience init() {
+        self.init(level: LogLevel.Debug)
     }
 
+    // MARK: LogDestinationProtocol
     public var identifier: String = NSUUID().UUIDString
     public var level: UInt
+    
+    /// Subclasses must override
+    public func log(detail: LogDetail) {
+        assert(false, "This method must be overriden by the subclass.")
+    }
 
-    public let dateFormatter: NSDateFormatter = NSThread.dateFormatter_ELLog(dateFormat)
-    internal static let dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+    // MARK: LogDestinationFormattible
+    public var showCaller: Bool
+    public var showLogLevel: Bool
+    public var showTimestamp: Bool
+    public var dateFormatter: NSDateFormatter
+    
+    public func formatted(detail: LogDetail) -> String {
+        var logString: String = ""
+        
+        if showLogLevel {
+            if let level = detail.level {
+                logString += "[\(LogLevel(rawValue: level).description)] "
+            }
+        }
+        
+        if showTimestamp {
+            if let date = detail.date {
+                logString += "[\(dateFormatter.stringFromDate(date))] "
+            }
+        }
+        
+        if showCaller {
+            if let filename = detail.filename, line = detail.line, function = detail.function {
+                logString += "(\(function), \((filename as NSString).lastPathComponent):\(line)) "
+            }
+        }
+        
+        logString += ": "
+        
+        if let message = detail.message {
+            logString += message
+        }
+        
+        return logString
+    }
 }

--- a/ELLogTests/LogConsoleDestinationTests.swift
+++ b/ELLogTests/LogConsoleDestinationTests.swift
@@ -50,28 +50,28 @@ class LogConsoleDestinationTests: XCTestCase {
         XCTAssertFalse(logConsoleDestination.showTimestamp)
         
         let expectedLogString = ": I am log."
-        XCTAssert(logConsoleDestination.formattedLogString(logDetailMock) == expectedLogString)
+        XCTAssert(logConsoleDestination.formatted(logDetailMock) == expectedLogString)
     }
     
     func testLogConsoleDestinationLevel() {
         let logConsoleDestination = LogConsoleDestination()
         logDetailMock.level = LogLevel.Verbose.rawValue
         let expectedLogString = "[VERBOSE] : I am log."
-        XCTAssert(logConsoleDestination.formattedLogString(logDetailMock) == expectedLogString)
+        XCTAssert(logConsoleDestination.formatted(logDetailMock) == expectedLogString)
     }
     
     func testLogConsoleDestinationCaller() {
         let logConsoleDestination = LogConsoleDestination()
         logConsoleDestination.showCaller = true
         let expectedLogString = "(testFunction, TestFilename.swift:42) : I am log."
-        XCTAssert(logConsoleDestination.formattedLogString(logDetailMock) == expectedLogString)
+        XCTAssert(logConsoleDestination.formatted(logDetailMock) == expectedLogString)
     }
     
     func testLogConsoleDestinationTimestamp() {
         let logConsoleDestination = LogConsoleDestination()
         logConsoleDestination.showTimestamp = true
         let expectedLogString = "[1970-01-01 00:00:00.000] : I am log."
-        XCTAssert(logConsoleDestination.formattedLogString(logDetailMock) == expectedLogString)
+        XCTAssert(logConsoleDestination.formatted(logDetailMock) == expectedLogString)
     }
     
     func testLogConsoleDestinationShowAll() {
@@ -81,6 +81,6 @@ class LogConsoleDestinationTests: XCTestCase {
         logDetailMock.level = LogLevel.Verbose.rawValue
         let expectedLogString = "[VERBOSE] [1970-01-01 00:00:00.000] (testFunction, TestFilename.swift:42) : I am log."
         logConsoleDestination.log(logDetailMock)
-        XCTAssert(logConsoleDestination.formattedLogString(logDetailMock) == expectedLogString)
+        XCTAssert(logConsoleDestination.formatted(logDetailMock) == expectedLogString)
     }
 }

--- a/ELLogTests/LogUnitTestDestination.swift
+++ b/ELLogTests/LogUnitTestDestination.swift
@@ -15,17 +15,19 @@ Defines a log destination that captures the last LogDetail logged.
 
  */
 @objc(ELLogUnitTestDestination)
-public class LogUnitTestDestination: LogDestinationBase, LogDestinationProtocol {
+public class LogUnitTestDestination: LogDestinationBase {
     
     /// The last LogDetail logged through this destination
     public var lastLogDetail: LogDetail = LogDetail()
 
-    // LogDestinationProtocol compliance
-    public var showCaller: Bool = false
-    public var showLogLevel: Bool = true
-    public var showTimestamp: Bool = false
+    public convenience init() {
+        self.init(level: LogLevel.Debug)
+        showCaller = false
+        showLogLevel = true
+        showTimestamp = false
+    }
 
-    public func log(detail: LogDetail) {
+    public override func log(detail: LogDetail) {
         lastLogDetail = detail
     }
     


### PR DESCRIPTION
@bsneed Please review.

**About this refactor**
This refactor is done for clarity, to remove duplication, and enable more reuse. The code that formatted the string to output in a log was duplicated in several classes. I've brought it into a protocol, `LogDestinationFormattible`,  that is implemented on the base class. This allows for simpler use while still allowing customizability in subclasses.
