### PR TITLE
Change how we pass vaArgs to Crashlytics

### DIFF
--- a/ELLog/Destinations/Crashlytics/LogCrashlyticsDestination.swift
+++ b/ELLog/Destinations/Crashlytics/LogCrashlyticsDestination.swift
@@ -56,8 +56,9 @@ public class LogCrashlyticsDestination: LogDestinationBase, LogDestinationProtoc
             output += message
         }
 
-        let emptyPointer = CVaListPointer(_fromUnsafeMutablePointer: nil)
-        CLSLogv(output, emptyPointer)
+        withVaList([]) { (pointer: CVaListPointer) in
+            CLSLogv(output, pointer)
+        }
     }
 }
 


### PR DESCRIPTION
use empty list to generate a pointer instead of nil which apparently causes crashes sometimes
