### PR TITLE
Add new unit test to catch Crashlytics crashes

### DIFF
--- a/ELLog/Destinations/Crashlytics/LogCrashlyticsDestination.swift
+++ b/ELLog/Destinations/Crashlytics/LogCrashlyticsDestination.swift
@@ -56,9 +56,7 @@ public class LogCrashlyticsDestination: LogDestinationBase, LogDestinationProtoc
             output += message
         }
 
-        withVaList([]) { (pointer: CVaListPointer) in
-            CLSLogv(output, pointer)
-        }
+        CLSLogv("%@", getVaList([output]))
     }
 }
 

--- a/ELLogTests/ CrashlyticsLogDestinationTests/ CrashlyticsLogDestinationTests.swift
+++ b/ELLogTests/ CrashlyticsLogDestinationTests/ CrashlyticsLogDestinationTests.swift
@@ -1,0 +1,36 @@
+//
+//  CrashlyticsLogDestinationTests.swift
+//  walmart
+//
+//  Created by Steven Riggins on 4/3/16.
+//  Copyright © 2016 Walmart. All rights reserved.
+//
+//
+
+// This test is not included as part of the ELLog test suit
+// because the Crashlytics logging code, while
+// in the ELLog framework *repository* is not in the ELLog *framework*
+// This allows ELLog to not rely on linking with Crashlytics
+// Include this file in any test suite using the CrashlyticsLogDestination
+
+import XCTest
+import Walmart
+import ELLog
+
+class CrashlyticsTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testForLoggingCrash() {
+        CrashlyticsLogger.sharedInstance.log(.Debug, message: "%@%d%.2f this would crash the older crashytics logging code")
+    }
+
+}

--- a/ELLogTests/ CrashlyticsLogDestinationTests/ CrashlyticsLogDestinationTests.swift
+++ b/ELLogTests/ CrashlyticsLogDestinationTests/ CrashlyticsLogDestinationTests.swift
@@ -31,6 +31,7 @@ class CrashlyticsTests: XCTestCase {
 
     func testForLoggingCrash() {
         CrashlyticsLogger.sharedInstance.log(.Debug, message: "%@%d%.2f this would crash the older crashytics logging code")
+        XCTAssert(true, "this is to make unit test servers happy that at least one assert runs")
     }
 
 }


### PR DESCRIPTION
Add a unit test that is not run by Travis (due to Crashlytics requirement) but users of ELLog can pull this test into their projects.
