### PR TITLE
Some more minor swift 3 cleanups

### DIFF
--- a/ELLog.xcodeproj/project.pbxproj
+++ b/ELLog.xcodeproj/project.pbxproj
@@ -273,6 +273,9 @@
 				LastUpgradeCheck = 0810;
 				ORGANIZATIONNAME = WalmartLabs;
 				TargetAttributes = {
+					CA24104F1AF966F600AA4410 = {
+						LastSwiftMigration = 0810;
+					};
 					CA8D47BA1AAE6FF50028B74D = {
 						CreatedOnToolsVersion = 6.3;
 						LastSwiftMigration = 0810;
@@ -396,6 +399,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -417,6 +421,7 @@
 				PRODUCT_NAME = ELLog;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -734,6 +739,7 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = QADeployment;
 		};

--- a/ELLog/Destinations/Crashlytics/LogCrashlyticsDestination.swift
+++ b/ELLog/Destinations/Crashlytics/LogCrashlyticsDestination.swift
@@ -47,7 +47,7 @@ public class LogCrashlyticsDestination: ELLog.LogDestinationBase {
         showTimestamp = true
     }
 
-    public override func log(detail: ELLog.LogDetail) {
+    public override func log(_ detail: ELLog.LogDetail) {
         var output: String = ""
 
         if showLogLevel {
@@ -58,12 +58,12 @@ public class LogCrashlyticsDestination: ELLog.LogDestinationBase {
 
         if showTimestamp {
             if let date = detail.date {
-                output += "[\(dateFormatter.stringFromDate(date))] "
+                output += "[\(dateFormatter.string(from: date))] "
             }
         }
 
         if showCaller {
-            if let filename = detail.filename, line = detail.line, function = detail.function {
+            if let filename = detail.filename, let line = detail.line, let function = detail.function {
                 output += "(\(function), \((filename as NSString).lastPathComponent):\(line)) "
             }
         }
@@ -77,4 +77,3 @@ public class LogCrashlyticsDestination: ELLog.LogDestinationBase {
         CLSLogv("%@", getVaList([output]))
     }
 }
-

--- a/ELLog/Destinations/LogConsoleDestination.swift
+++ b/ELLog/Destinations/LogConsoleDestination.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /**
-LogConsoleDestination provides output to the console via NSLog. 
+LogConsoleDestination provides output to the console via NSLog.
 
 The default behavior is:
 
@@ -19,7 +19,7 @@ The default behavior is:
     showTimestamp = false
 */
 @objc(ELLogConsoleDestination)
-open class LogConsoleDestination: LogDestinationBase {
+public class LogConsoleDestination: LogDestinationBase {
 
     public override init(level: LogLevel) {
         super.init(level: level)
@@ -27,19 +27,17 @@ open class LogConsoleDestination: LogDestinationBase {
         showLogLevel = true
         showTimestamp = false
     }
-    
+
     public convenience init() {
         self.init(level: .Debug)
     }
-    
-    open override func log(_ detail: LogDetail) {
+
+    public override func log(_ detail: LogDetail) {
         let logString = formatted(detail)
         // You must pass NSLog a format string and then pass the Swift string as a vaArg
         // or the code will crash when it tries to format %f in the Swift string
         NSLog("%@", logString)
     }
-    
+
 }
-
-
 

--- a/ELLog/Destinations/LogTextfileDestination.swift
+++ b/ELLog/Destinations/LogTextfileDestination.swift
@@ -20,7 +20,7 @@ The default behavior is:
     showTimestamp = true
 */
 @objc(ELLogTextfileDestination)
-open class LogTextfileDestination: LogDestinationBase {
+public class LogTextfileDestination: LogDestinationBase {
 
     fileprivate let filename: String
     fileprivate let outputStream: OutputStream?
@@ -28,7 +28,7 @@ open class LogTextfileDestination: LogDestinationBase {
     public init(filename: String) {
         self.filename = filename
 
-        let folder = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0] 
+        let folder = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]
         let path = (folder as NSString).appendingPathComponent(filename)
         outputStream = OutputStream(toFileAtPath: path, append: true)
 
@@ -39,7 +39,7 @@ open class LogTextfileDestination: LogDestinationBase {
         }
 
         super.init(level: .Debug)
-        
+
         showCaller = false
         showLogLevel = true
         showTimestamp = true
@@ -49,19 +49,19 @@ open class LogTextfileDestination: LogDestinationBase {
         outputStream?.close()
     }
 
-    open override func log(_ detail: LogDetail) {
+    public override func log(_ detail: LogDetail) {
 
         if outputStream == nil {
             return
         }
-        
+
         outputStream?.write(formatted(detail))
     }
 }
 
 
 extension OutputStream {
-    
+
     @discardableResult
     func write(_ string: String, encoding: String.Encoding = String.Encoding.utf8, allowLossyConversion: Bool = true) -> Int {
         if let data = string.data(using: encoding, allowLossyConversion: allowLossyConversion) {
@@ -82,8 +82,8 @@ extension OutputStream {
 
             return totalBytesWritten
         }
-        
+
         return -1
     }
-    
+
 }

--- a/ELLog/Logger.swift
+++ b/ELLog/Logger.swift
@@ -14,21 +14,21 @@ Logging Level option flags.
 public struct LogLevel: OptionSet, CustomStringConvertible {
     /// Logging disabled.
     public let rawValue: UInt
-    
+
     public static let None = LogLevel(rawValue: 0)
-    
+
     /// Error logging enabled.
     public static let Error = LogLevel(rawValue: 1 << 0)
-    
+
     /// Debug logging enabled.
     public static let Debug = LogLevel(rawValue: 1 << 1)
-    
+
     /// Info logging enabled.
     public static let Info = LogLevel(rawValue: 1 << 2)
-    
+
     /// Verbose logging enabled.
     public static let Verbose = LogLevel(rawValue: 1 << 3)
-    
+
     /// All logging enabled.
     public static let All:LogLevel = [.Error, .Debug, .Info, .Verbose]
 
@@ -39,11 +39,11 @@ public struct LogLevel: OptionSet, CustomStringConvertible {
         if self == .None {
             return "NONE"
         }
-        
+
         if contains(LogLevel.All) {
             return "ALL"
         }
-        
+
         if contains(.Error) {
             options.append("ERROR")
         }
@@ -64,9 +64,6 @@ public struct LogLevel: OptionSet, CustomStringConvertible {
     }
 
     public init(rawValue: UInt) { self.rawValue = rawValue }
-    //todo WARNING BooleanType has been removed
-    // BooleanType
-    public var boolValue: Bool { return rawValue  != 0 }
 }
 
 /**
@@ -81,7 +78,7 @@ open class Logger: NSObject {
     The default logger instance.  This is typically a LogConsoleDestination with a log level of .Debug.
     */
     open static let defaultInstance = loggerDefault()
-    
+
     /**
     Allows this logger to be enabled/disabled.
     */
@@ -99,7 +96,7 @@ open class Logger: NSObject {
         }
     }
     fileprivate var _enabled = true
-    
+
     public override init() {
         super.init()
         let console = LogConsoleDestination(level: [.Debug, .Error])
@@ -125,7 +122,7 @@ open class Logger: NSObject {
     Add a new destination to this Logger instance.  This appends another destination
     to the list.  Only messages with a log level matching what this destination consumes
     will be sent here.
-    
+
     - parameter destination: The destination to add.
     - returns: the identifier of the destination.  Useful for later lookup.
     */
@@ -155,7 +152,7 @@ open class Logger: NSObject {
     open func destination(_ identifier: String) -> LogDestinationProtocol? {
         return destinations[identifier]
     }
-    
+
     /**
     Don't call this.  This is purely for interacting with the objective-c interface to this class.
     */
@@ -176,7 +173,7 @@ open class Logger: NSObject {
         if !enabled {
             return
         }
-        
+
         // cycle through the destinations and start writing.
         for destination in destinations.values {
             if let rawLevel = detail.level {
@@ -199,7 +196,7 @@ open class Logger: NSObject {
     internal func destinationsForTesting() -> [String: LogDestinationProtocol] {
         return destinations
     }
-    
+
     fileprivate var destinations = [String: LogDestinationProtocol]()
 }
 

--- a/ELLogTests/ELLogTests.swift
+++ b/ELLogTests/ELLogTests.swift
@@ -40,9 +40,7 @@ class ELLogTests: XCTestCase {
         
         let testMessage = "hello \(number)"
         let testLogLevel: LogLevel = [.Debug, .Info]
-        
-        XCTAssert(testLogLevel.boolValue == true)
-        
+
         logger.log(testLogLevel, message: testMessage)
         XCTAssert(unitTestDestination.lastLogDetail.level == testLogLevel.rawValue)
         XCTAssert(unitTestDestination.lastLogDetail.message == testMessage)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ELLog 
 
-[![Version](https://img.shields.io/badge/version-v2.1.0-blue.svg)](https://github.com/Electrode-iOS/ELLog/releases/latest)
+[![Version](https://img.shields.io/badge/version-v3.0.0-blue.svg)](https://github.com/Electrode-iOS/ELLog/releases/latest)
 [![Build Status](https://travis-ci.org/Electrode-iOS/ELLog.svg?branch=master)](https://travis-ci.org/Electrode-iOS/ELLog)
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
@@ -8,7 +8,7 @@ ELLog is a framework that provides versatile logging options for Swift and Objec
 
 ## Requirements
 
-ELLog requires Swift 2.3 and Xcode 8.
+ELLog requires Swift 3 and Xcode 8.1.
 
 ## Installation
 
@@ -17,7 +17,7 @@ ELLog requires Swift 2.3 and Xcode 8.
 Install with [Carthage](https://github.com/Carthage/Carthage) by adding the framework to your project's [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile).
 
 ```
-github "Electrode-iOS/ELLog" ~> 2.1.0
+github "Electrode-iOS/ELLog" ~> 3.0.0
 ```
 
 ### Manual


### PR DESCRIPTION
* Concrete Destination are now `public` not `open 
* Removed conformance to `BooleanType`
* Update macOS framework to have swift 3 version as well
* Updated read me to reflect swift 3, including bumping Release number to 3.0.0 (this is not yet reflected in github releases
* Updated Crashlytics example file to Swift 3 syntax. 

Let me know if you want me to break any of these out into a separate PR. 