### PR TITLE
Log levels were incorrect. Info should not be more permissive than De…

### DIFF
--- a/ELLog/Logger-Objc.h
+++ b/ELLog/Logger-Objc.h
@@ -11,8 +11,8 @@
 typedef NS_ENUM(NSUInteger, ELLogLevel) {
     ELLogLevelNone = 0,
     ELLogLevelError = 1 << 0,
-    ELLogLevelDebug = 1 << 1,
-    ELLogLevelInfo = 1 << 2,
+    ELLogLevelInfo = 1 << 1,
+    ELLogLevelDebug = 1 << 2,
     ELLogLevelVerbose = 1 << 3,
     ELLogLevelAll = ELLogLevelError | ELLogLevelDebug | ELLogLevelInfo | ELLogLevelVerbose
 };

--- a/ELLog/Logger.swift
+++ b/ELLog/Logger.swift
@@ -20,11 +20,11 @@ public struct LogLevel: OptionSet, CustomStringConvertible {
     /// Error logging enabled.
     public static let Error = LogLevel(rawValue: 1 << 0)
 
-    /// Debug logging enabled.
-    public static let Debug = LogLevel(rawValue: 1 << 1)
-
     /// Info logging enabled.
-    public static let Info = LogLevel(rawValue: 1 << 2)
+    public static let Info = LogLevel(rawValue: 1 << 1)
+    
+    /// Debug logging enabled.
+    public static let Debug = LogLevel(rawValue: 1 << 2)
 
     /// Verbose logging enabled.
     public static let Verbose = LogLevel(rawValue: 1 << 3)

--- a/ELLogTests/ELLogTests.swift
+++ b/ELLogTests/ELLogTests.swift
@@ -79,6 +79,10 @@ class ELLogTests: XCTestCase {
         XCTAssertFalse(level.contains(LogLevel.All))
         
         XCTAssertTrue(level.contains(.Info))
+        
+        XCTAssertTrue(LogLevel.Error.rawValue < LogLevel.Info.rawValue)
+        XCTAssertTrue(LogLevel.Info.rawValue < LogLevel.Debug.rawValue)
+        XCTAssertTrue(LogLevel.Debug.rawValue < LogLevel.Verbose.rawValue)
     }
     
 }


### PR DESCRIPTION
…bug.