### PR TITLE
Add a static framework target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: objective-c
 osx_image: xcode9.3
 
 script:
-   - xcodebuild -project ELLog.xcodeproj -scheme ELLog -sdk iphonesimulator test -destination 'platform=iOS Simulator,name=iPhone X,OS=11.1' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELLog.xcodeproj -scheme ELLog -sdk iphonesimulator clean test -destination 'platform=iOS Simulator,name=iPhone X,OS=11.1' CODE_SIGNING_REQUIRED=NO
+   - xcodebuild -project ELLog.xcodeproj -scheme ELLog_static -sdk iphonesimulator clean build -destination 'platform=iOS Simulator,name=iPhone X,OS=11.1' CODE_SIGNING_REQUIRED=NO

--- a/ELLog.xcodeproj/project.pbxproj
+++ b/ELLog.xcodeproj/project.pbxproj
@@ -9,6 +9,15 @@
 /* Begin PBXBuildFile section */
 		20C3E9201C64099A002BC2DA /* LogUnitTestDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C3E91F1C64099A002BC2DA /* LogUnitTestDestination.swift */; };
 		2238B6B81C9B6D1F00C3E813 /* LogConsoleDestinationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2238B6B71C9B6D1F00C3E813 /* LogConsoleDestinationTests.swift */; };
+		3EBC4B7E20E55C2D00013E61 /* NSThread+ELLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA13BBD31AB894D700165813 /* NSThread+ELLog.swift */; };
+		3EBC4B7F20E55C2D00013E61 /* LogTextfileDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA13BBD01AB8946400165813 /* LogTextfileDestination.swift */; };
+		3EBC4B8020E55C2D00013E61 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB30EF81AB660F00021C342 /* Logger.swift */; };
+		3EBC4B8120E55C2D00013E61 /* Logger-Objc.m in Sources */ = {isa = PBXBuildFile; fileRef = CAB30F011AB6766C0021C342 /* Logger-Objc.m */; };
+		3EBC4B8220E55C2D00013E61 /* LogConsoleDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB30EFE1AB663C70021C342 /* LogConsoleDestination.swift */; };
+		3EBC4B8320E55C2D00013E61 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8D47D71AAE702C0028B74D /* Log.swift */; };
+		3EBC4B8420E55C2D00013E61 /* LogDestinationBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CACE89211AC1CC78000FE30E /* LogDestinationBase.swift */; };
+		3EBC4B8720E55C2D00013E61 /* Logger-Objc.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB30F001AB6766C0021C342 /* Logger-Objc.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3EBC4B8820E55C2D00013E61 /* ELLog.h in Headers */ = {isa = PBXBuildFile; fileRef = CA8D47C01AAE6FF50028B74D /* ELLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CA13BBD11AB8946400165813 /* LogTextfileDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA13BBD01AB8946400165813 /* LogTextfileDestination.swift */; };
 		CA13BBD41AB894D700165813 /* NSThread+ELLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA13BBD31AB894D700165813 /* NSThread+ELLog.swift */; };
 		CA2410511AF966F600AA4410 /* NSThread+ELLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA13BBD31AB894D700165813 /* NSThread+ELLog.swift */; };
@@ -45,6 +54,7 @@
 /* Begin PBXFileReference section */
 		20C3E91F1C64099A002BC2DA /* LogUnitTestDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogUnitTestDestination.swift; sourceTree = "<group>"; };
 		2238B6B71C9B6D1F00C3E813 /* LogConsoleDestinationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogConsoleDestinationTests.swift; sourceTree = "<group>"; };
+		3EBC4B8E20E55C2D00013E61 /* ELLog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELLog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA13BBD01AB8946400165813 /* LogTextfileDestination.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogTextfileDestination.swift; sourceTree = "<group>"; };
 		CA13BBD31AB894D700165813 /* NSThread+ELLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSThread+ELLog.swift"; sourceTree = "<group>"; };
 		CA2410631AF966F600AA4410 /* ELLog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ELLog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -67,6 +77,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3EBC4B8520E55C2D00013E61 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA24105A1AF966F600AA4410 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -117,6 +134,7 @@
 				CA8D47BB1AAE6FF50028B74D /* ELLog.framework */,
 				CA8D47C61AAE6FF50028B74D /* ELLogTests.xctest */,
 				CA2410631AF966F600AA4410 /* ELLog.framework */,
+				3EBC4B8E20E55C2D00013E61 /* ELLog.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -178,6 +196,15 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		3EBC4B8620E55C2D00013E61 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EBC4B8720E55C2D00013E61 /* Logger-Objc.h in Headers */,
+				3EBC4B8820E55C2D00013E61 /* ELLog.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA24105B1AF966F600AA4410 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -199,6 +226,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		3EBC4B7C20E55C2D00013E61 /* ELLog_static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3EBC4B8A20E55C2D00013E61 /* Build configuration list for PBXNativeTarget "ELLog_static" */;
+			buildPhases = (
+				3EBC4B7D20E55C2D00013E61 /* Sources */,
+				3EBC4B8520E55C2D00013E61 /* Frameworks */,
+				3EBC4B8620E55C2D00013E61 /* Headers */,
+				3EBC4B8920E55C2D00013E61 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ELLog_static;
+			productName = ELLog;
+			productReference = 3EBC4B8E20E55C2D00013E61 /* ELLog.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		CA24104F1AF966F600AA4410 /* ELLog_osx */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CA2410601AF966F600AA4410 /* Build configuration list for PBXNativeTarget "ELLog_osx" */;
@@ -289,6 +334,7 @@
 			projectRoot = "";
 			targets = (
 				CA8D47BA1AAE6FF50028B74D /* ELLog */,
+				3EBC4B7C20E55C2D00013E61 /* ELLog_static */,
 				CA8D47C51AAE6FF50028B74D /* ELLogTests */,
 				CA24104F1AF966F600AA4410 /* ELLog_osx */,
 			);
@@ -296,6 +342,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		3EBC4B8920E55C2D00013E61 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA24105F1AF966F600AA4410 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -320,6 +373,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		3EBC4B7D20E55C2D00013E61 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EBC4B7E20E55C2D00013E61 /* NSThread+ELLog.swift in Sources */,
+				3EBC4B7F20E55C2D00013E61 /* LogTextfileDestination.swift in Sources */,
+				3EBC4B8020E55C2D00013E61 /* Logger.swift in Sources */,
+				3EBC4B8120E55C2D00013E61 /* Logger-Objc.m in Sources */,
+				3EBC4B8220E55C2D00013E61 /* LogConsoleDestination.swift in Sources */,
+				3EBC4B8320E55C2D00013E61 /* Log.swift in Sources */,
+				3EBC4B8420E55C2D00013E61 /* LogDestinationBase.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CA2410501AF966F600AA4410 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -370,6 +437,61 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		3EBC4B8B20E55C2D00013E61 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELLog/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.walmartlabs.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = ELLog;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		3EBC4B8C20E55C2D00013E61 /* QADeployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELLog/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.walmartlabs.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = ELLog;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = QADeployment;
+		};
+		3EBC4B8D20E55C2D00013E61 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = ELLog/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.walmartlabs.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = ELLog;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
 		CA2410611AF966F600AA4410 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -761,6 +883,16 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		3EBC4B8A20E55C2D00013E61 /* Build configuration list for PBXNativeTarget "ELLog_static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3EBC4B8B20E55C2D00013E61 /* Debug */,
+				3EBC4B8C20E55C2D00013E61 /* QADeployment */,
+				3EBC4B8D20E55C2D00013E61 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		CA2410601AF966F600AA4410 /* Build configuration list for PBXNativeTarget "ELLog_osx" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ github "Electrode-iOS/ELLog"
 Install manually by adding `ELLog.xcodeproj` to your project and configuring your target to link `ELLog.framework` from `ELLog` target.
 
 There are two target that builds `ELLog.framework`.
-1. `ELLog`: Creates dynamicly linked `ELLog.framework.`
-2. `ELLog_static`: Creates staticly linked `ELLog.framework`.
+1. `ELLog`: Creates dynamically linked `ELLog.framework.`
+2. `ELLog_static`: Creates statically linked `ELLog.framework`.
 
 Both targets build the same product (`ELLog.framework`), thus linking the same app against both `ELLog` and `ELLog_static` should be avoided.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ github "Electrode-iOS/ELLog"
 
 ### Manual
 
-Install manually by adding `ELLog.xcodeproj` to your project and configuring your target to link `ELLog.framework`.
+Install manually by adding `ELLog.xcodeproj` to your project and configuring your target to link `ELLog.framework` from `ELLog` target.
+
+There are two target that builds `ELLog.framework`.
+1. `ELLog`: Creates dynamicly linked `ELLog.framework.`
+2. `ELLog_static`: Creates staticly linked `ELLog.framework`.
+
+Both targets build the same product (`ELLog.framework`), thus linking the same app against both `ELLog` and `ELLog_static` should be avoided.
 
 ## Introduction
 


### PR DESCRIPTION
This change adds a new target named `ELLog_static`. This target builds a static version of `ELLog.framework.` 
- It shares the same source files as dynamic ELLog framework and builds a product with the same name. 
- Framework's module name is also the same as that of dynamic framework.
- It uses the same Info.plist file as dynamic framework target.
- Travis script is updated to build both targets and clean before building.

Going forward, `ELLog_static` framework needs to be managed as well as `ELLog` target. Sources added or removed, build setting changes, build phase changes should be reflected on `ELLog_static` target.

